### PR TITLE
Use integration test loader

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.0.0
+    version: 6.9.1
 test:
   override:
     # Run lint

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ test:
     - npm run lint
     #- npm test
     # Run integration test suite
-    #- npm run integration
+    - npm run integration
     # Run tests with coverage
     #- npm test --coverage -- -R spec-xunit-file
     # Extract test artifacts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "integration": "integration all"
   },
   "repository": {
     "type": "git",
@@ -46,6 +47,7 @@
     "eslint": "^2.7.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.2"
+    "eslint-plugin-standard": "^1.3.2",
+    "five-bells-integration-test": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
-    "integration": "integration all"
+    "integration": "integration-loader && integration all"
   },
   "repository": {
     "type": "git",
@@ -48,6 +48,12 @@
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
-    "five-bells-integration-test": "^5.0.0"
+    "five-bells-integration-test-loader": "^1.0.0"
+  },
+  "config": {
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
+    }
   }
 }


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* interledgerjs/five-bells-ledger@b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader