### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "co": "^4.6.0",
     "co-emitter": "^0.2.3",
     "co-request": "^1.0.0",
-    "five-bells-condition": "^3.0.0",
-    "five-bells-shared": "^14.0.0",
+    "five-bells-condition": "^4.0.0",
+    "five-bells-shared": "^21.1.0",
     "koa": "^1.2.0",
     "koa-bodyparser": "^2.0.1",
     "koa-mag": "^1.0.4",
@@ -44,10 +44,10 @@
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "eslint": "^2.7.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.2",
+    "eslint": "^3.12.2",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
     "five-bells-integration-test-loader": "^1.0.0"
   },
   "config": {


### PR DESCRIPTION
Fun fact: This was the last thing in the Interledger.js integration tests that depended on bcrypt. (Now removed with the five-bells-shared version bump.)